### PR TITLE
优化代码：当server连接不OK时，不再检查其他server连接，直接返回错误

### DIFF
--- a/cpp/src/msg_server/MsgConn.cpp
+++ b/cpp/src/msg_server/MsgConn.cpp
@@ -386,10 +386,10 @@ void CMsgConn::_HandleLoginRequest(CImPduLoginRequest* pPdu)
 	if (!pDbConn) {
 		result = REFUSE_REASON_NO_DB_SERVER;
 	}
-	if (!is_login_server_available()) {
+	else if (!is_login_server_available()) {
 		result = REFUSE_REASON_NO_LOGIN_SERVER;
 	}
-	if (!is_route_server_available()) {
+	else if (!is_route_server_available()) {
 		result = REFUSE_REASON_NO_ROUTE_SERVER;
 	}
 


### PR DESCRIPTION
当server连接不OK时，不再检查其他server连接，直接返回错误，去掉不必要地检查其他服务器状态　