### PR TITLE
CSExplode类的小改良

### DIFF
--- a/cpp/src/base/util.cpp
+++ b/cpp/src/base/util.cpp
@@ -272,7 +272,7 @@ CStrExplode::CStrExplode(char* str, char seperator)
 	int idx = 0;
 	char* start = pos = str;
 	while (*pos) {
-		if (*pos == seperator) {
+		if (*pos == seperator && pos != start) {
 			uint32_t len = pos - start;
 			m_item_list[idx] = new char [len + 1];
 			strncpy(m_item_list[idx], start, len);
@@ -286,9 +286,11 @@ CStrExplode::CStrExplode(char* str, char seperator)
 	}
 
 	uint32_t len = pos - start;
-	m_item_list[idx] = new char [len + 1];
-	strncpy(m_item_list[idx], start, len);
-	m_item_list[idx][len]  = '\0';
+	if(len != 0){
+		m_item_list[idx] = new char [len + 1];
+		strncpy(m_item_list[idx], start, len);
+		m_item_list[idx][len]  = '\0';
+	} 
 }
 
 CStrExplode::~CStrExplode()


### PR DESCRIPTION
当该类构造函数中的字符串str的首尾包含分隔符（seperator）的时候，之前的代码会做多余的空间分配操作，
其结果是m_item_list字符串数组的首尾两个元素仅仅保存了一个'\0'而已。
